### PR TITLE
🐛 FIX: Assignment 4 at the wrong place

### DIFF
--- a/07_object_oriented_programming/README.md
+++ b/07_object_oriented_programming/README.md
@@ -75,17 +75,3 @@ Protocols are similar to abstract data classes. So when should you use a protoco
 After this lesson you should:
 
 - Know what Protocol classes are and when to use them.
-
----
-
-## Assignment #4
-
-This assignment is about OOP and VSCode shortcuts, make sure you have those in mind!
-
-### Assignment #4 covers
-
-- Enums
-- Object composition
-- Testing objects
-
-Open your assignment project and let's go!

--- a/08_text_editors/README.md
+++ b/08_text_editors/README.md
@@ -7,3 +7,17 @@ The focus of this module is VSCode (sorry, PyCharm fans!). We cover the basic Py
 1. Follow the [Setup tutorial for VSCode](./1_setup.md) and get your VSCode ready for Python development.
 2. Master [Productivity on VSCode](./2_productivity.md) and learn how to use shortcuts to become a more productive developer.
 3. Learn how to [Debug on VSCode](./3_debugging.md). Your `print` statements days are over!
+
+---
+
+## Assignment #4
+
+This assignment is about OOP and VSCode shortcuts, make sure you have those in mind!
+
+### Assignment #4 covers
+
+- Enums
+- Object composition
+- Testing objects
+
+Open your assignment project and let's go!


### PR DESCRIPTION
Assignment 4 should come after Text Editors, not OOP. This happened due to the fact we planned to have the Text Editors module before OOP in the past.